### PR TITLE
Changed: ZoneId for UTC

### DIFF
--- a/src/main/scala/just/utc/JDateTimeInUtc.scala
+++ b/src/main/scala/just/utc/JDateTimeInUtc.scala
@@ -7,10 +7,11 @@ import java.time.{Instant, LocalDateTime, ZoneId, ZoneOffset}
   * @since 2018-09-12
   */
 object JDateTimeInUtc {
-  val zoneId: ZoneId = ZoneId.ofOffset("UTC", ZoneOffset.UTC)
+  final val ZoneOffsetUtc: ZoneOffset = ZoneOffset.UTC
+  final val ZoneIdUtc: ZoneId = ZoneOffsetUtc
 
   def toLocalDateTime(millis: Long): LocalDateTime =
-    LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), zoneId)
+    LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneIdUtc)
 
   def toEpochMilli(localDateTime: LocalDateTime): Long =
     localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli


### PR DESCRIPTION
Changed: `ZoneId` for UTC from `ZoneId.ofOffset("UTC", ZoneOffset.UTC)` to just `ZoneOffset.UTC`