### PR TITLE
Close #21 - Keep Instant in Utc instead of epoch milliseconds (Long)

### DIFF
--- a/src/main/scala/just/utc/DateTimeError.scala
+++ b/src/main/scala/just/utc/DateTimeError.scala
@@ -1,0 +1,32 @@
+package just.utc
+
+import java.time.DateTimeException
+
+/**
+  * @author Kevin Lee
+  * @since 2020-04-21
+  */
+sealed trait DateTimeError
+
+object DateTimeError {
+  final case class ExceededInstantRange(
+    millis: Long
+  , min: Long
+  , max: Long
+  , cause: DateTimeException
+  ) extends DateTimeError
+
+  final case class ExceededLocalDateTimeRange(millis: Long, cause: DateTimeException) extends DateTimeError
+
+  def exceededInstantRange(
+    millis: Long
+  , min: Long
+  , max: Long
+  , cause: DateTimeException
+  ): DateTimeError =
+    ExceededInstantRange(millis, min, max, cause)
+
+  def exceededLocalDateTimeRange(millis: Long, cause: DateTimeException): DateTimeError =
+    ExceededLocalDateTimeRange(millis, cause)
+
+}

--- a/src/main/scala/just/utc/Utc.scala
+++ b/src/main/scala/just/utc/Utc.scala
@@ -2,8 +2,10 @@ package just.utc
 
 import java.time.format.DateTimeFormatter
 import java.time.temporal.WeekFields
-import java.time.{Clock, LocalDateTime}
+import java.time.{Clock, DateTimeException, Instant, LocalDateTime}
 import java.util.Locale
+
+import just.utc.JDateTimeInUtc.ZoneIdUtc
 
 import scala.math.Ordered
 
@@ -11,9 +13,22 @@ import scala.math.Ordered
   * @author Kevin Lee
   * @since 2018-09-12
   */
-final case class Utc(epochMillis: Long) extends Ordered[Utc] {
+final class Utc private (val instant: Instant) extends Ordered[Utc] {
 
-  lazy val jLocalDateTime: LocalDateTime = JDateTimeInUtc.toLocalDateTime(epochMillis)
+  lazy val epochMillis: Long = instant.toEpochMilli
+
+  override lazy val hashCode: Int = epochMillis.hashCode()
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  override def equals(that: Any): Boolean = that match {
+    case thatUtc: Utc => this.epochMillis == thatUtc.epochMillis
+    case _ => false
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
+  override def toString: String = s"Utc($epochMillis)"
+
+  lazy val jLocalDateTime: LocalDateTime = LocalDateTime.ofInstant(instant, ZoneIdUtc)
 
   def dayOfWeek: Int = jLocalDateTime.getDayOfWeek.getValue
 
@@ -47,8 +62,35 @@ object Utc {
     override def compare(x: Utc, y: Utc): Int = x.compare(y)
   }
 
-  def now(): Utc = Utc(Clock.systemUTC().millis())
+  def unapply(utc: Utc): Option[Instant] =
+    Option(utc).map(_.instant)
+
+  def now(): Utc = new Utc(Instant.ofEpochMilli(Clock.systemUTC().millis()))
+
+  def fromEpochMillis(epochMillis: Long): Either[DateTimeError, Utc] =
+    try {
+      Right(new Utc(Instant.ofEpochMilli(epochMillis)))
+    } catch {
+      case dateTimeException: DateTimeException =>
+        Left(
+          DateTimeError.exceededInstantRange(
+            epochMillis
+            , Instant.MIN.getEpochSecond
+            , Instant.MAX.getEpochSecond
+            , dateTimeException)
+        )
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def unsafeFromEpochMillis(epochMillis: Long): Utc =
+    fromEpochMillis(epochMillis) match {
+      case Right(utc) => utc
+      case Left(DateTimeError.ExceededInstantRange(_, _, _, cause)) => throw cause
+      case Left(DateTimeError.ExceededLocalDateTimeRange(_, cause)) => throw cause
+
+    }
+
 
   def fromUtcLocalDateTime(localDateTime: LocalDateTime): Utc =
-    Utc(JDateTimeInUtc.toEpochMilli(localDateTime))
+    new Utc(localDateTime.toInstant(JDateTimeInUtc.ZoneOffsetUtc))
 }

--- a/src/test/scala/just/utc/UtcSpec.scala
+++ b/src/test/scala/just/utc/UtcSpec.scala
@@ -1,5 +1,7 @@
 package just.utc
 
+import java.time.Instant
+
 import hedgehog._
 import hedgehog.runner._
 
@@ -23,8 +25,12 @@ object UtcSpec extends Properties {
   , property("testMoreThanOrEqualTo_EqualCase", testMoreThanOrEqualTo_EqualCase)
   )
 
+  val validInstantMin: Long = Instant.MIN.getEpochSecond
+  val validInstantMax: Long = Instant.MAX.getEpochSecond
+
+  // TODO: Do invalid range handling test as well
   def testFromUtcLocalDateTime: Property = for {
-    expected <- Gen.long(Range.linear(1L, Long.MaxValue)).log("expected")
+    expected <- Gen.long(Range.linear(validInstantMin, validInstantMax)).log("expected")
   } yield {
     val localDateTime = JDateTimeInUtc.toLocalDateTime(expected)
     val actual = Utc.fromUtcLocalDateTime(localDateTime)
@@ -32,56 +38,58 @@ object UtcSpec extends Properties {
   }
 
   def testCompareToLess: Property = for {
-    x <- Gen.long(Range.linear(Long.MinValue, Long.MaxValue >> 1)).forAll
-    y <- Gen.long(Range.linear(1L, Long.MaxValue >> 1)).forAll
-  } yield Utc(x).compare(Utc(x + y)) ==== -1
+    x <- Gen.long(Range.linear(validInstantMin, validInstantMax)).forAll
+    y <- Gen.long(Range.linear(1L, validInstantMax)).forAll
+  } yield Utc.unsafeFromEpochMillis(x).compare(Utc.unsafeFromEpochMillis(x + y)) ==== -1
 
   def testCompareToMore: Property = for {
-    x <- Gen.long(Range.linear(Long.MinValue >> 1, Long.MaxValue)).forAll
-    y <- Gen.long(Range.linear(1L, Long.MaxValue >> 1)).forAll
-  } yield Utc(x).compare(Utc(x - y)) ==== 1
+    x <- Gen.long(Range.linear(validInstantMin, Long.MaxValue)).forAll
+    y <- Gen.long(Range.linear(1L, validInstantMax)).forAll
+  } yield Utc.unsafeFromEpochMillis(x).compare(Utc.unsafeFromEpochMillis(x - y)) ==== 1
 
   def testCompareToEqual: Property = for {
-    x <- Gen.long(Range.linear(Long.MinValue, Long.MaxValue)).forAll
-  } yield Utc(x).compare(Utc(x)) ==== 0
+    x <- Gen.long(Range.linear(validInstantMin, validInstantMax)).forAll
+  } yield Utc.unsafeFromEpochMillis(x).compare(Utc.unsafeFromEpochMillis(x)) ==== 0
 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   def testEqual: Property = for {
-    x <- Gen.long(Range.linear(Long.MinValue, Long.MaxValue)).forAll
-  } yield Result.assert(Utc(x) == Utc(x))
+    x <- Gen.long(Range.linear(validInstantMin, validInstantMax)).forAll
+  } yield {
+    Result.assert(Utc.unsafeFromEpochMillis(x) == Utc.unsafeFromEpochMillis(x))
+  }
 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   def testNotEqual: Property = for {
-    x <- Gen.long(Range.linear(Long.MinValue, Long.MaxValue)).forAll
-    y <- Gen.long(Range.linear(Long.MinValue, Long.MaxValue)).filter(_ != x).forAll
-  } yield Result.assert(Utc(x) != Utc(y))
+    x <- Gen.long(Range.linear(validInstantMin, validInstantMax)).forAll
+    y <- Gen.long(Range.linear(validInstantMin, validInstantMax)).filter(_ != x).forAll
+  } yield Result.assert(Utc.unsafeFromEpochMillis(x) != Utc.unsafeFromEpochMillis(y))
 
   def testLess: Property = for {
-    x <- Gen.long(Range.linear(Long.MinValue, Long.MaxValue >> 1)).forAll
-    y <- Gen.long(Range.linear(1L, Long.MaxValue >> 1)).forAll
-  } yield Result.assert(Utc(x) < Utc(x + y))
+    x <- Gen.long(Range.linear(validInstantMin, validInstantMax)).forAll
+    y <- Gen.long(Range.linear(1L, validInstantMax)).forAll
+  } yield Result.assert(Utc.unsafeFromEpochMillis(x) < Utc.unsafeFromEpochMillis(x + y))
 
   def testLessThanOrEqualTo_LessCase: Property = for {
-    x <- Gen.long(Range.linear(Long.MinValue, Long.MaxValue >> 1)).forAll
-    y <- Gen.long(Range.linear(1L, Long.MaxValue >> 1)).forAll
-  } yield Result.assert(Utc(x) <= Utc(x + y))
+    x <- Gen.long(Range.linear(validInstantMin, validInstantMax)).forAll
+    y <- Gen.long(Range.linear(1L, validInstantMax)).forAll
+  } yield Result.assert(Utc.unsafeFromEpochMillis(x) <= Utc.unsafeFromEpochMillis(x + y))
 
   def testLessThanOrEqualTo_EqualCase: Property = for {
-    x <- Gen.long(Range.linear(Long.MinValue, Long.MaxValue)).forAll
-  } yield Result.assert(Utc(x) <= Utc(x))
+    x <- Gen.long(Range.linear(validInstantMin, validInstantMax)).forAll
+  } yield Result.assert(Utc.unsafeFromEpochMillis(x) <= Utc.unsafeFromEpochMillis(x))
 
   def testMore: Property = for {
-    x <- Gen.long(Range.linear(Long.MinValue >> 1, Long.MaxValue)).forAll
-    y <- Gen.long(Range.linear(1L, Long.MaxValue >> 1)).forAll
-  } yield Result.assert(Utc(x) > Utc(x - y))
+    x <- Gen.long(Range.linear(validInstantMin, Long.MaxValue)).forAll
+    y <- Gen.long(Range.linear(1L, validInstantMax)).forAll
+  } yield Result.assert(Utc.unsafeFromEpochMillis(x) > Utc.unsafeFromEpochMillis(x - y))
 
   def testMoreThanOrEqualTo_MoreCase: Property = for {
-    x <- Gen.long(Range.linear(Long.MinValue >> 1, Long.MaxValue)).forAll
-    y <- Gen.long(Range.linear(1L, Long.MaxValue >> 1)).forAll
-  } yield Result.assert(Utc(x) >= Utc(x - y))
+    x <- Gen.long(Range.linear(validInstantMin, Long.MaxValue)).forAll
+    y <- Gen.long(Range.linear(1L, validInstantMax)).forAll
+  } yield Result.assert(Utc.unsafeFromEpochMillis(x) >= Utc.unsafeFromEpochMillis(x - y))
 
   def testMoreThanOrEqualTo_EqualCase: Property = for {
-    x <- Gen.long(Range.linear(Long.MinValue, Long.MaxValue)).forAll
-  } yield Result.assert(Utc(x) >= Utc(x))
+    x <- Gen.long(Range.linear(validInstantMin, validInstantMax)).forAll
+  } yield Result.assert(Utc.unsafeFromEpochMillis(x) >= Utc.unsafeFromEpochMillis(x))
 
 }


### PR DESCRIPTION
Close #21 - Keep `Instant` in `Utc` instead of epoch milliseconds (`Long`)