### PR TITLE
Close #55 - Fix `Utc.now(): Utc` for Scala 3

### DIFF
--- a/src/main/scala-3/just/utc/Utc.scala
+++ b/src/main/scala-3/just/utc/Utc.scala
@@ -67,7 +67,7 @@ object Utc {
   def unapply(utc: Utc): Option[Instant] =
     Option(utc).map(_.instant)
 
-  def now(): Utc = new Utc(Instant.ofEpochMilli(Clock.systemUTC().millis()))
+  def now(): Utc = new Utc(Clock.systemUTC().instant())
 
   def fromEpochMillis(epochMillis: Long): Either[DateTimeError, Utc] =
     try {


### PR DESCRIPTION
Close #55 - Fix `Utc.now(): Utc` for Scala 3