### PR TITLE
Close #54 - Add `milliSeconds`: Int to `Utc`

### DIFF
--- a/src/main/scala-2/just/utc/Utc.scala
+++ b/src/main/scala-2/just/utc/Utc.scala
@@ -4,7 +4,7 @@ import just.fp.syntax._
 import just.utc.JDateTimeInUtc.ZoneIdUtc
 
 import java.time.format.DateTimeFormatter
-import java.time.temporal.WeekFields
+import java.time.temporal.{ChronoField, WeekFields}
 import java.time.{Clock, DateTimeException, Instant, LocalDateTime}
 import java.util.Locale
 
@@ -40,6 +40,8 @@ final class Utc private (val instant: Instant) extends Ordered[Utc] {
   def minute: Int = jLocalDateTime.getMinute
 
   def seconds: Int = jLocalDateTime.getSecond
+
+  def milliSeconds: Int = instant.get(ChronoField.MILLI_OF_SECOND)
 
   /** Returns the week of a week based year using Locale.ROOT
     *

--- a/src/main/scala-3/just/utc/Utc.scala
+++ b/src/main/scala-3/just/utc/Utc.scala
@@ -4,7 +4,7 @@ import just.fp.syntax.*
 import just.utc.JDateTimeInUtc.ZoneIdUtc
 
 import java.time.format.DateTimeFormatter
-import java.time.temporal.WeekFields
+import java.time.temporal.{ChronoField, WeekFields}
 import java.time.{Clock, DateTimeException, Instant, LocalDateTime}
 import java.util.Locale
 import scala.math.Ordered
@@ -42,6 +42,8 @@ final class Utc private (val instant: Instant) extends Ordered[Utc] derives CanE
   def minute: Int = jLocalDateTime.getMinute
 
   def seconds: Int = jLocalDateTime.getSecond
+
+  def milliSeconds: Int = instant.get(ChronoField.MILLI_OF_SECOND)
 
   /** Returns the week of a week based year using Locale.ROOT
     *

--- a/src/test/scala/just/utc/UtcSpec.scala
+++ b/src/test/scala/just/utc/UtcSpec.scala
@@ -22,7 +22,9 @@ object UtcSpec extends Properties {
     property("testMore", testMore),
     property("testMoreThanOrEqualTo_MoreCase", testMoreThanOrEqualTo_MoreCase),
     property("testMoreThanOrEqualTo_EqualCase", testMoreThanOrEqualTo_EqualCase),
-    property("test Utc.fromInstant", testFromInstant)
+    property("test Utc.fromInstant", testFromInstant),
+    property("testMoreThanOrEqualTo_EqualCase", testMoreThanOrEqualTo_EqualCase),
+    property("test milliSeconds", testMilliSeconds)
   )
 
   val validInstantMin: Long = Long.MinValue + 1
@@ -113,5 +115,13 @@ object UtcSpec extends Properties {
       val actual   = utc.instant
       actual ==== expected
     }
+
+  def testMilliSeconds: Property = for {
+    now      <- Gen.constant(Instant.now()).log("now")
+    expected <- Gen.constant(now.getNano / 1000000).log("expected")
+  } yield {
+    val actual = Utc.fromInstant(now)
+    actual.milliSeconds ==== expected
+  }
 
 }


### PR DESCRIPTION
Close #54 - Add `milliSeconds`: Int to `Utc`