### PR TITLE
Fix #59 - Fix `Utc.epochMillisWithNanos`

### DIFF
--- a/src/main/scala-2/just/utc/Utc.scala
+++ b/src/main/scala-2/just/utc/Utc.scala
@@ -13,7 +13,7 @@ import java.util.Locale
   */
 final class Utc private (val instant: Instant) extends Ordered[Utc] {
 
-  lazy val epochMillisWithNanos: Long = instant.toEpochMilli * 1000000L + instant.getNano
+  lazy val epochMillisWithNanos: Long = instant.toEpochMilli / 1000L * 1000000000L + instant.getNano
 
   lazy val epochMillis: Long = instant.toEpochMilli
 

--- a/src/main/scala-3/just/utc/Utc.scala
+++ b/src/main/scala-3/just/utc/Utc.scala
@@ -14,7 +14,7 @@ import scala.math.Ordered
   */
 final class Utc private (val instant: Instant) extends Ordered[Utc] derives CanEqual {
 
-  lazy val epochMillisWithNanos: Long = instant.toEpochMilli * 1_000_000L + instant.getNano
+  lazy val epochMillisWithNanos: Long = instant.toEpochMilli / 1000L * 1_000_000_000L + instant.getNano
 
   lazy val epochMillis: Long = instant.toEpochMilli
 

--- a/src/test/scala/just/utc/UtcSpec.scala
+++ b/src/test/scala/just/utc/UtcSpec.scala
@@ -24,6 +24,7 @@ object UtcSpec extends Properties {
     property("testMoreThanOrEqualTo_EqualCase", testMoreThanOrEqualTo_EqualCase),
     property("test Utc.fromInstant", testFromInstant),
     property("testMoreThanOrEqualTo_EqualCase", testMoreThanOrEqualTo_EqualCase),
+    property("test epochMillisWithNanos", testEpochMillisWithNanos),
     property("test milliSeconds", testMilliSeconds)
   )
 
@@ -115,6 +116,14 @@ object UtcSpec extends Properties {
       val actual   = utc.instant
       actual ==== expected
     }
+
+  def testEpochMillisWithNanos: Property = for {
+    now      <- Gen.constant(Instant.now()).log("now")
+    expected <- Gen.constant(now.toEpochMilli * 1000000 + now.getNano % 1000000).log("expected")
+  } yield {
+    val actual = Utc.fromInstant(now)
+    actual.epochMillisWithNanos ==== expected
+  }
 
   def testMilliSeconds: Property = for {
     now      <- Gen.constant(Instant.now()).log("now")


### PR DESCRIPTION
Fix #59 - Fix `Utc.epochMillisWithNanos`