### PR TITLE
Close #86 - Rename `renderWith` to `renderWithFormatter`

### DIFF
--- a/src/main/scala-2/just/utc/Utc.scala
+++ b/src/main/scala-2/just/utc/Utc.scala
@@ -56,7 +56,7 @@ final class Utc private (val instant: Instant) extends Ordered[Utc] {
 
   lazy val render: String = jLocalDateTime.toString
 
-  def renderWith(dateTimeFormatter: DateTimeFormatter): String =
+  def renderWithFormatter(dateTimeFormatter: DateTimeFormatter): String =
     jLocalDateTime.format(dateTimeFormatter)
 
 }

--- a/src/main/scala-3/just/utc/Utc.scala
+++ b/src/main/scala-3/just/utc/Utc.scala
@@ -58,7 +58,7 @@ final class Utc private (val instant: Instant) extends Ordered[Utc] derives CanE
 
   lazy val render: String = jLocalDateTime.toString
 
-  def renderWith(dateTimeFormatter: DateTimeFormatter): String =
+  def renderWithFormatter(dateTimeFormatter: DateTimeFormatter): String =
     jLocalDateTime.format(dateTimeFormatter)
 
 }


### PR DESCRIPTION
Close #86 - Rename `renderWith` to `renderWithFormatter`