### PR TITLE
Update Scala, sbt and sbt plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         scala:
           - { version: "2.11.12", binary-version: "2.11", java-version: "11", java-distribution: "temurin" }
-          - { version: "2.12.14", binary-version: "2.12", java-version: "11", java-distribution: "temurin" }
-          - { version: "2.13.10", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
-          - { version: "3.0.0",   binary-version: "3"   , java-version: "11", java-distribution: "temurin" }
+          - { version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin" }
+          - { version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
+          - { version: "3.3.6",   binary-version: "3"   , java-version: "11", java-distribution: "temurin" }
 
     steps:
       - uses: actions/checkout@v5
@@ -41,4 +41,4 @@ jobs:
       - name: Build for Scala 2.13
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: .github/workflows/sbt-build.sh 2.13.10
+        run: .github/workflows/sbt-build.sh 2.13.16

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 3.3", version: "3.3.1", binary-version: "3", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 3.3", version: "3.3.6", binary-version: "3", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v5

--- a/build.sbt
+++ b/build.sbt
@@ -24,12 +24,21 @@ ThisBuild / licenses := List(License.MIT)
 lazy val justUtc = (project in file("."))
   .settings(
     name := prefixedProjectName(""),
+    libraryDependencies := crossVersionProps(List(libs.justFp), SemVer.parseUnsafe(scalaVersion.value)) {
+      case (SemVer.Major(2), SemVer.Minor(11), _) =>
+        libraryDependencies
+          .value
+          .filterNot(m => m.organization == "org.wartremover" && m.name == "wartremover")
+      case x =>
+        libraryDependencies.value
+    },
+
   )
   .aggregate(core)
 
 lazy val core = module("core").settings(
   libraryDependencies := crossVersionProps(List(libs.justFp), SemVer.parseUnsafe(scalaVersion.value)) {
-    case (SemVer.Major(2), SemVer.Minor(10), _) =>
+    case (SemVer.Major(2), SemVer.Minor(11), _) =>
       libraryDependencies
         .value
         .filterNot(m => m.organization == "org.wartremover" && m.name == "wartremover")
@@ -61,7 +70,7 @@ lazy val props = new {
 
   val ProjectName = "just-utc"
 
-  final val CrossScalaVersions  = Seq("2.11.12", "2.12.13", "2.13.10", "3.0.0").distinct
+  final val CrossScalaVersions  = Seq("2.11.12", "2.12.18", "2.13.16", "3.3.6").distinct
   final val ProjectScalaVersion = CrossScalaVersions.last
 
   final val JustFpVersion = "1.6.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.1
+sbt.version=1.11.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.21")
-addSbtPlugin("org.scoverage"   % "sbt-scoverage"   % "2.0.7")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.4.1")
+addSbtPlugin("org.scoverage"   % "sbt-scoverage"   % "2.3.1")
 addSbtPlugin("org.scoverage"   % "sbt-coveralls"   % "1.3.11")
 
 val SbtDevOopsVersion = "3.1.0"


### PR DESCRIPTION
Update Scala, sbt and sbt plugin

- Upgrade sbt: 1.10.1 -> 1.11.6
- Upgrade sbt-wartremover: 2.4.21 -> 3.4.1
- Update Scala cross-compilation versions:
  - 2.12.13 -> 2.12.18
  - 2.13.10 -> 2.13.16
  - 3.0.0 -> 3.3.6
- Remove wartremover for Scala 2.11 (the latest version not available for 2.11)